### PR TITLE
Fix Multi-turn conversations bug

### DIFF
--- a/backend/app/rag/utils.py
+++ b/backend/app/rag/utils.py
@@ -154,6 +154,9 @@ async def replace_image_content(messages):
     for message in new_messages:
         if "content" not in message:
             continue
+
+        if not isinstance(message['content'], list):
+            continue
         
         new_content = []  # 创建新的内容列表
         # 遍历content中的每个内容项


### PR DESCRIPTION
# Problem
The original `replace_image_content` will regard a string as a list, which comes from the assistant messages, in the form of `{"role": "assistant", "content": "XXXX"}`. Therefore, the assistant message string will be converted into a list of string, which is illegal as a request with respect to OpenAI API. Eventually this leads to a `BadRequest` error.

# Solution
This issue can be easily fixed by checking if the content is a list before `replace_image_content` starts to convert `image_url` to base64 encoding.

# Logs
```
backend-1  | 2025-06-10 16:59:30,430 - app.core.logging - INFO - chat 'GinSin_601a914e-dc88-4edf-960b-6ca68fa8b809 uses system prompt 你是一个在大模型领域的专家'
backend-1  | 2025-06-10 16:59:30,491 - httpx - INFO - HTTP Request: POST http://model-server:8005/embed_text "HTTP/1.1 200 OK"
backend-1  | 2025-06-10 16:59:39,131 - aiokafka.consumer.group_coordinator - WARNING - Heartbeat failed: local member_id was not recognized; resetting and re-joining group
backend-1  | 2025-06-10 16:59:39,131 - aiokafka.consumer.group_coordinator - ERROR - Heartbeat session expired - marking coordinator dead
backend-1  | 2025-06-10 16:59:39,131 - aiokafka.consumer.group_coordinator - WARNING - Marking the coordinator dead (node 0)for group task_consumer_group.
backend-1  | 2025-06-10 16:59:39,333 - app.core.logging - INFO - test_messages: [{'role': 'system', 'content': [{'type': 'text', 'text': '你是一个在大模型领域的专家'}]}, {'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uzdeVxM3+M/8Ntekha0EC'}}, {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uz9eVxM//8//p/2Fa2yU0'}}, {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uz9dzyW//8//h82pSRK0d'}}, {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uzdZXgT2eP//dOmLhRKgS'}}, {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uzdd1zN//8//mdbklEatp'}}, {'type': 'text', 'text': '使用HITACHI的设备得到的测量值如果超出了允许的范围，该设备会进行哪些处理呢'}]}, {'role': 'assistant', 'content': ['根', '据', '提', '供', '的', '文', '档', '内', '容', '，', '当', '所', '述', '重', '叠', '测', '量', '系', '统', '使', '用', 'H', 'I', 'T', 'A', 'C', 'H', 'I', '设', '备', '得', '到', '的', '测', '量', '值', '超', '出', '了', '允', '许', '的', '范', '围', '时', '，', '系', '统', '会', '进', '行', '如', '下', '处', '理', '：', '\n', '\n', '#', '#', '#', ' ', '一', '、', '测', '量', '值', '超', '范', '围', '的', '处', '理', '逻', '辑', '\n', '1', '.', ' ', '*', '*', '测', '量', '值', '超', '范', '围', '检', '测', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '系', '统', '会', '实', '时', '监', '测', '从', '反', '射', '电', '子', '检', '测', '器', '、', '二', '次', '电', '子', '检', '测', '器', '以', '及', '信', '号', '电', '子', '中', '获', '取', '的', '测', '量', '值', '。', '\n', ' ', ' ', ' ', '-', ' ', '当', '这', '些', '测', '量', '值', '（', '如', '反', '射', '电', '子', '像', '的', '亮', '度', '、', '二', '次', '电', '子', '像', '的', '信', '号', '或', '基', '于', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '推', '定', '的', '线', '图', '案', '位', '置', '信', '息', '）', '超', '出', '了', '预', '设', '的', '允', '许', '范', '围', '时', '，', '系', '统', '会', '触', '发', '处', '理', '逻', '辑', '。', '\n', '\n', '2', '.', ' ', '*', '*', '调', '整', '电', '子', '束', '和', '检', '测', '参', '数', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '如', '果', '反', '射', '电', '子', '像', '或', '二', '次', '电', '子', '像', '的', '亮', '度', '、', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '的', '计', '算', '结', '果', '超', '出', '了', '允', '许', '的', '范', '围', '，', '系', '统', '可', '能', '会', '调', '整', '电', '子', '光', '学', '系', '统', '的', '参', '数', '，', '包', '括', '电', '子', '束', '的', '能', '量', '、', '强', '度', '或', '扫', '描', '速', '度', '。', '\n', ' ', ' ', ' ', '-', ' ', '通', '过', '增', '加', '或', '减', '少', '电', '子', '束', '的', '加', '速', '电', '压', '、', '调', '整', '检', '测', '器', '的', '灵', '敏', '度', '或', '改', '变', '信', '号', '处', '理', '的', '阈', '值', '，', '以', '调', '整', '测', '量', '值', '回', '到', '允', '许', '的', '范', '围', '内', '。', '\n', '\n', '3', '.', ' ', '*', '*', '图', '像', '质', '量', '优', '化', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '如', '果', '二', '次', '电', '子', '像', '或', '反', '射', '电', '子', '像', '的', '质', '量', '（', '如', '分', '辨', '率', '、', '信', '噪', '比', '等', '）', '较', '差', '，', '系', '统', '会', '优', '化', '图', '像', '处', '理', '算', '法', '，', '例', '如', '：', '\n', ' ', ' ', ' ', ' ', ' ', '-', ' ', '应', '用', '平', '滑', '化', '滤', '波', '、', '边', '缘', '增', '强', '或', '噪', '声', '去', '除', '等', '预', '处', '理', '步', '骤', '。', '\n', ' ', ' ', ' ', ' ', ' ', '-', ' ', '调', '整', '图', '像', '的', '累', '计', '帧', '数', '，', '通', '过', '多', '次', '累', '加', '降', '低', '噪', '声', '，', '提', '高', '图', '像', '的', '对', '比', '度', '和', '分', '辨', '率', '。', '\n', '\n', '4', '.', ' ', '*', '*', '调', '整', '测', '量', '算', '法', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '当', '基', '于', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '推', '定', '的', '线', '图', '案', '位', '置', '信', '息', '超', '出', '允', '许', '范', '围', '时', '，', '系', '统', '会', '重', '新', '评', '估', '和', '调', '整', '测', '量', '算', '法', '。', '\n', ' ', ' ', ' ', '-', ' ', '修', '改', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '的', '生', '成', '逻', '辑', '，', '例', '如', '调', '整', '沿', '线', '图', '案', '长', '度', '方', '向', '的', '亮', '度', '信', '息', '相', '加', '策', '略', '，', '确', '保', '生', '成', '的', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '更', '准', '确', '。', '\n', '\n', '5', '.', ' ', '*', '*', '重', '叠', '误', '差', '再', '计', '算', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '在', '图', '像', '质', '量', '优', '化', '和', '算', '法', '调', '整', '后', '，', '系', '统', '会', '重', '新', '计', '算', '试', '样', '的', '重', '叠', '误', '差', '。', '\n', ' ', ' ', ' ', '-', ' ', '使', '用', '优', '化', '后', '的', '反', '射', '电', '子', '像', '和', '二', '次', '电', '子', '像', '进', '行', '重', '叠', '误', '差', '的', '计', '算', '，', '确', '保', '结', '果', '更', '加', '精', '确', '。', '\n', '\n', '#', '#', '#', ' ', '二', '、', '综', '合', '处', '理', '流', '程', '\n', '1', '.', ' ', '*', '*', '实', '时', '监', '测', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '系', '统', '在', '运', '行', '过', '程', '中', '，', '持', '续', '监', '测', '二', '次', '电', '子', '像', '、', '反', '射', '电', '子', '像', '的', '亮', '度', '信', '息', '和', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '推', '定', '的', '线', '图', '案', '位', '置', '信', '息', '。', '\n', ' ', ' ', ' ', '\n', '2', '.', ' ', '*', '*', '异', '常', '检', '测', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '当', '测', '量', '值', '超', '出', '允', '许', '范', '围', '时', '，', '系', '统', '立', '即', '触', '发', '异', '常', '处', '理', '逻', '辑', '。', '\n', ' ', ' ', ' ', '\n', '3', '.', ' ', '*', '*', '参', '数', '调', '整', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '调', '整', '电', '子', '束', '的', '参', '数', '（', '如', '加', '速', '电', '压', '、', '电', '流', '强', '度', '）', '和', '检', '测', '器', '的', '灵', '敏', '度', '。', '\n', ' ', ' ', ' ', '-', ' ', '调', '整', '图', '像', '处', '理', '算', '法', '，', '优', '化', '亮', '度', '信', '息', '的', '处', '理', '。', '\n', '\n', '4', '.', ' ', '*', '*', '重', '新', '计', '算', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '基', '于', '调', '整', '后', '的', '参', '数', '和', '算', '法', '，', '重', '新', '生', '成', '二', '次', '电', '子', '像', '、', '反', '射', '电', '子', '像', '以', '及', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '。', '\n', ' ', ' ', ' ', '-', ' ', '重', '新', '计', '算', '试', '样', '的', '重', '叠', '误', '差', '。', '\n', '\n', '5', '.', ' ', '*', '*', '验', '证', '与', '反', '馈', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '系', '统', '会', '验', '证', '处', '理', '后', '的', '测', '量', '值', '是', '否', '符', '合', '允', '许', '的', '范', '围', '。', '\n', ' ', ' ', ' ', '-', ' ', '如', '果', '仍', '然', '不', '满', '足', '要', '求', '，', '可', '能', '会', '进', '一', '步', '调', '整', '参', '数', '或', '重', '新', '重', '复', '上', '述', '步', '骤', '，', '直', '到', '满', '足', '精', '度', '要', '求', '。', '\n', '\n', '#', '#', '#', ' ', '三', '、', '关', '键', '技', '术', '点', '\n', '1', '.', ' ', '*', '*', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '的', '生', '成', '和', '调', '整', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '系', '统', '动', '态', '调', '整', 'S', 'U', 'M', 'L', 'I', 'N', 'E', '轮', '廓', '的', '生', '成', '逻', '辑', '，', '确', '保', '其', '准', '确', '反', '映', '线', '图', '案', '的', '位', '置', '信', '息', '。', '\n', '\n', '2', '.', ' ', '*', '*', '图', '像', '质', '量', '优', '化', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '应', '用', '平', '滑', '化', '滤', '波', '器', '、', '边', '缘', '增', '强', '等', '技', '术', '，', '优', '化', '反', '射', '电', '子', '像', '和', '二', '次', '电', '子', '像', '的', '质', '量', '。', '\n', '\n', '3', '.', ' ', '*', '*', '测', '量', '算', '法', '的', '灵', '活', '调', '整', '*', '*', '：', '\n', ' ', ' ', ' ', '-', ' ', '根', '据', '检', '测', '到', '的', '异', '常', '，', '调', '整', '测', '量', '算', '法', '，', '以', '适', '应', '不', '同', '工', '况', '下', '的', '图', '像', '处', '理', '需', '求', '。', '\n', '\n', '#', '#', '#', ' ', '总', '结', '\n', '当', '测', '量', '值', '超', '出', '允', '许', '范', '围', '时', '，', '系', '统', '会', '通', '过', '调', '整', '电', '子', '束', '参', '数', '、', '优', '化', '图', '像', '处', '理', '算', '法', '和', '重', '新', '计', '算', '测', '量', '值', '的', '方', '式', '，', '确', '保', '测', '量', '结', '果', '的', '准', '确', '性', '。', '整', '个', '过', '程', '涉', '及', '动', '态', '调', '整', '、', '实', '时', '反', '馈', '和', '综', '合', '优', '化', '，', '以', '满', '足', '高', '精', '度', '半', '导', '体', '制', '造', '中', '对', '重', '叠', '测', '量', '的', '严', '格', '要', '求', '。']}, {'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uzdeVxM3+M/8Ntekha0EC'}}, {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uz9eVxM//8//p/2Fa2yU0'}}, {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uz9dzyW//8//h82pSRK0d'}}, {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uzdZXgT2eP//dOmLhRKgS'}}, {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABnYAAAkjCAIAAACzq+aSAAEAAElEQVR42uzdd1zN//8//mdbklEatp'}}, {'type': 'text', 'text': '使用HITACHI的设备得到的测量值如果超出了允许的范围，该设备会进行哪些处理呢'}]}]

backend-1  | 2025-06-10 16:59:43,676 - httpx - INFO - HTTP Request: POST https://api.siliconflow.cn/v1/chat/completions "HTTP/1.1 400 Bad Request"
backend-1  | [2025-06-10 16:59:43 +0800] [26] [ERROR] Exception in ASGI application
backend-1  | Traceback (most recent call last):
backend-1  |   File "/usr/local/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
backend-1  |     result = await app(  # type: ignore[func-returns-value]
backend-1  |   File "/usr/local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
backend-1  |     return await self.app(scope, receive, send)
backend-1  | 2025-06-10 16:59:43,681 - uvicorn.error - ERROR - Exception in ASGI application
backend-1  | Traceback (most recent call last):
backend-1  |   File "/usr/local/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
backend-1  |     result = await app(  # type: ignore[func-returns-value]
backend-1  |   File "/usr/local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
backend-1  |     return await self.app(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/fastapi/applications.py", line 1054, in __call__
backend-1  |     await super().__call__(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/applications.py", line 112, in __call__
backend-1  |     await self.middleware_stack(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 187, in __call__
backend-1  |     raise exc
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 165, in __call__
backend-1  |     await self.app(scope, receive, _send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 93, in __call__
backend-1  |     await self.simple_response(scope, receive, send, request_headers=headers)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 144, in simple_response
backend-1  |     await self.app(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
backend-1  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
backend-1  |     raise exc
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
backend-1  |     await app(scope, receive, sender)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 714, in __call__
backend-1  |     await self.middleware_stack(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 734, in app
backend-1  |     await route.handle(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 288, in handle
backend-1  |     await self.app(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 76, in app
backend-1  |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
backend-1  |     raise exc
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
backend-1  |     await app(scope, receive, sender)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 74, in app
backend-1  |     await response(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 262, in __call__
backend-1  |     with collapse_excgroups():
backend-1  |   File "/usr/local/lib/python3.10/contextlib.py", line 153, in __exit__
backend-1  |   File "/usr/local/lib/python3.10/site-packages/fastapi/applications.py", line 1054, in __call__
backend-1  |     self.gen.throw(typ, value, traceback)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
backend-1  |     raise exc
backend-1  |     await super().__call__(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 266, in wrap
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/applications.py", line 112, in __call__
backend-1  |     await func()
backend-1  |     await self.middleware_stack(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 246, in stream_response
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 187, in __call__
backend-1  |     async for chunk in self.body_iterator:
backend-1  |     raise exc
backend-1  |   File "/app/app/rag/llm_service.py", line 206, in create_chat_stream
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 165, in __call__
backend-1  |     response = await client.chat.completions.create(
backend-1  |     await self.app(scope, receive, _send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 93, in __call__
backend-1  |   File "/usr/local/lib/python3.10/site-packages/openai/resources/chat/completions/completions.py", line 2000, in create
backend-1  |     await self.simple_response(scope, receive, send, request_headers=headers)
backend-1  |     return await self._post(
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 144, in simple_response
backend-1  |   File "/usr/local/lib/python3.10/site-packages/openai/_base_client.py", line 1767, in post
backend-1  |     await self.app(scope, receive, send)
backend-1  |     return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
backend-1  |   File "/usr/local/lib/python3.10/site-packages/openai/_base_client.py", line 1461, in request
backend-1  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
backend-1  |     raise exc
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
backend-1  |     await app(scope, receive, sender)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 714, in __call__
backend-1  |     await self.middleware_stack(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 734, in app
backend-1  |     await route.handle(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 288, in handle
backend-1  |     await self.app(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 76, in app
backend-1  |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
backend-1  |     raise exc
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
backend-1  |     await app(scope, receive, sender)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 74, in app
backend-1  |     await response(scope, receive, send)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 262, in __call__
backend-1  |     with collapse_excgroups():
backend-1  |   File "/usr/local/lib/python3.10/contextlib.py", line 153, in __exit__
backend-1  |     self.gen.throw(typ, value, traceback)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
backend-1  |     raise exc
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 266, in wrap
backend-1  |     await func()
backend-1  |   File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 246, in stream_response
backend-1  |     async for chunk in self.body_iterator:
backend-1  |   File "/app/app/rag/llm_service.py", line 206, in create_chat_stream
backend-1  |     response = await client.chat.completions.create(
backend-1  |   File "/usr/local/lib/python3.10/site-packages/openai/resources/chat/completions/completions.py", line 2000, in create
backend-1  |     return await self._post(
backend-1  |   File "/usr/local/lib/python3.10/site-packages/openai/_base_client.py", line 1767, in post
backend-1  |     return await self._request(
backend-1  |     return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
backend-1  |   File "/usr/local/lib/python3.10/site-packages/openai/_base_client.py", line 1461, in request
backend-1  |     return await self._request(
backend-1  |   File "/usr/local/lib/python3.10/site-packages/openai/_base_client.py", line 1562, in _request
backend-1  |     raise self._make_status_error_from_response(err.response) from None
backend-1  | openai.BadRequestError: Error code: 400 - {'code': 20015, 'message': 'The parameter is invalid. Please check again.', 'data': None}
backend-1  |   File "/usr/local/lib/python3.10/site-packages/openai/_base_client.py", line 1562, in _request
backend-1  |     raise self._make_status_error_from_response(err.response) from None
backend-1  | openai.BadRequestError: Error code: 400 - {'code': 20015, 'message': 'The parameter is invalid. Please check again.', 'data': None}
```